### PR TITLE
Fix last page link in paginate view

### DIFF
--- a/lib/turbo_html/views/paginate_view.ex
+++ b/lib/turbo_html/views/paginate_view.ex
@@ -139,7 +139,7 @@ defmodule Turbo.HTML.Views.PaginateView do
         page_link("#", :disabled, do: label)
 
       false ->
-        page_link(gen_href(conn, current_page + 1), do: label)
+        page_link(gen_href(conn, total_pages), do: label)
     end
   end
 


### PR DESCRIPTION
In the `Turbo.HTML.Views.PaginateView` module the `last_page_link` function should point to the last page instead of the next page.