### PR TITLE
Support input "type" option

### DIFF
--- a/lib/turbo_html/views/search_input_view.ex
+++ b/lib/turbo_html/views/search_input_view.ex
@@ -21,7 +21,8 @@ defmodule Turbo.HTML.Views.SearchInputView do
       name: field,
       value: value,
       class: Keyword.get(opts, :class),
-      placeholder: Keyword.get(opts, :placeholder)
+      placeholder: Keyword.get(opts, :placeholder),
+      type: Keyword.get(opts, :type, "text")
     )
   end
 
@@ -29,7 +30,8 @@ defmodule Turbo.HTML.Views.SearchInputView do
     content_tag(:input, "",
       name: field,
       class: Keyword.get(opts, :class),
-      placeholder: Keyword.get(opts, :placeholder)
+      placeholder: Keyword.get(opts, :placeholder),
+      type: Keyword.get(opts, :type, "text")
     )
   end
 end


### PR DESCRIPTION
Adds support for passing input "type" option to `turbo_search_input`. This is useful if you want to change the type of input....falls back to `input[type="text"]` default.

Usage:

```elixir
<%= turbo_search_input f, "q[name_or_summary_ilike]", placeholder: "Search", type: "search" %>
```